### PR TITLE
Handle error when operationAST name is undefined

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ const netCache = new InMemoryCache();
 const localCache = new InMemoryCache();
 const cache = ApolloCacheRouter.override(
   ApolloCacheRouter.route([netCache, localCache], document => {
+    const astName = getOperationAST(document).name;
     if (hasDirectives(['client'], document)
-        || getOperationAST(document).name.value === 'GeneratedClientQuery') {
+        || (astName && astName.value === 'GeneratedClientQuery')) {
       // Pass all @client queries and @client defaults to localCache
       return [localCache];
     } else {

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ const netCache = new InMemoryCache();
 const localCache = new InMemoryCache();
 const cache = ApolloCacheRouter.override(
   ApolloCacheRouter.route([netCache, localCache], document => {
-    const astName = getOperationAST(document).name;
+    const operationName = getOperationAST(document).name;
     if (hasDirectives(['client'], document)
-        || (astName && astName.value === 'GeneratedClientQuery')) {
+        || (operationName && operationName.value === 'GeneratedClientQuery')) {
       // Pass all @client queries and @client defaults to localCache
       return [localCache];
     } else {


### PR DESCRIPTION
Handle error when ```getOperationAST(document).name``` is ```undefined```